### PR TITLE
[Bookmarklet] Quick fix loading base version string instead of just build number, and test for version data correctly

### DIFF
--- a/res/code/_get-version.php
+++ b/res/code/_get-version.php
@@ -24,9 +24,10 @@
         // For now, we use alpha from local instance of s.keyman.com because 
         // downloads.keyman.com may be out of sync with s.keyman.com for alpha.
         // As we stablise the CI server, we may be able to eliminate this
-        $json = file_get_contents($this->versionJsonFilename);
-        if($json === NULL) {
+        $json = @file_get_contents($this->versionJsonFilename);
+        if($json === FALSE) {
           $json = @file_get_contents("{$this->downloadsApiVersionUrl}/$platform");
+          var_dump($json);
         }
 
         if($json !== NULL && $json !== FALSE) {

--- a/res/code/_get-version.php
+++ b/res/code/_get-version.php
@@ -27,7 +27,6 @@
         $json = @file_get_contents($this->versionJsonFilename);
         if($json === FALSE) {
           $json = @file_get_contents("{$this->downloadsApiVersionUrl}/$platform");
-          var_dump($json);
         }
 
         if($json !== NULL && $json !== FALSE) {

--- a/res/code/_test-get-version.php
+++ b/res/code/_test-get-version.php
@@ -2,19 +2,19 @@
   require_once('./_get-version.php');
   $keymanVersion = new KeymanVersion();
   $ver = $keymanVersion->getVersion('web', 'stable');
-	echo "Stable: $ver\n";
+  echo "Stable: $ver\n";
   if(empty($ver)) {
     $ver = $keymanVersion->getVersion('web', 'beta');
-		echo "Beta: $ver\n";
+    echo "Beta: $ver\n";
     if(empty($ver)) {
       $ver = $keymanVersion->getVersion('web', 'alpha');
-			echo "Alpha: $ver\n";
+      echo "Alpha: $ver\n";
       if(empty($ver)) {
         echo "console.log('ERROR: KeymanWeb version not found');";
         exit;
       }
     }
   }
-	
-	echo $ver;
+  
+  echo $ver;
 ?>

--- a/res/code/_test-get-version.php
+++ b/res/code/_test-get-version.php
@@ -1,0 +1,20 @@
+<?php
+  require_once('./_get-version.php');
+  $keymanVersion = new KeymanVersion();
+  $ver = $keymanVersion->getVersion('web', 'stable');
+	echo "Stable: $ver\n";
+  if(empty($ver)) {
+    $ver = $keymanVersion->getVersion('web', 'beta');
+		echo "Beta: $ver\n";
+    if(empty($ver)) {
+      $ver = $keymanVersion->getVersion('web', 'alpha');
+			echo "Alpha: $ver\n";
+      if(empty($ver)) {
+        echo "console.log('ERROR: KeymanWeb version not found');";
+        exit;
+      }
+    }
+  }
+	
+	echo $ver;
+?>

--- a/res/code/bml.php
+++ b/res/code/bml.php
@@ -86,8 +86,10 @@
   $keymanVersion = new KeymanVersion();
   $ver = $keymanVersion->getVersion('web', 'stable');
   if(empty($ver)) {
+    echo "console.log('WARNING: KeymanWeb stable version not found');\n";
     $ver = $keymanVersion->getVersion('web', 'beta');
     if(empty($ver)) {
+      echo "console.log('WARNING: KeymanWeb beta version not found');\n";
       $ver = $keymanVersion->getVersion('web', 'alpha');
       if(empty($ver)) {
         echo "console.log('ERROR: KeymanWeb version not found');";
@@ -106,20 +108,9 @@
   
   // Read the KeymanWeb code from s.keyman.com/
   $KeymanWebRoot = "{$KeymanCloudRootPath}kmw\\engine\\{$ver}";
-  
-  //
-  // Note: we need at least version 2.0.465
-  //
-  
-  if(intval($build) < 465) {
-    echo "console.log('KeymanWeb ($ver) build $build is lower than 465. This may cause KeymanWeb to fail.');";
-  }
 
-  if(intval($ver_array[0]) >= 10) {
-    $kmwbase = "keyman";
-  } else {
-    $kmwbase = "tavultesoft.keymanweb";
-  }
+  // We always load latest stable, which at 10.0 and later, uses `keyman` as global var
+  $kmwbase = "keyman";
  
   if($debug) {
     echo getutf8(file_get_contents("{$KeymanWebRoot}\\src\\kmwstring.js"));
@@ -139,11 +130,10 @@
   
   echo <<<END
 (function() {
-  //console.log('path');
   $kmwbase.init({
-    root: "//{$StaticResourceDomain}/kmw/engine/{$build}/", 
-    resources: "//{$StaticResourceDomain}/kmw/engine/{$build}/", 
-    keyboards: "//{$StaticResourceDomain}/keyboard/",
+    root: "https://{$StaticResourceDomain}/kmw/engine/{$ver}/", 
+    resources: "https://{$StaticResourceDomain}/kmw/engine/{$ver}/", 
+    keyboards: "https://{$StaticResourceDomain}/keyboard/",
     ui: "toggle"
   });
   $kmwbase.addKeyboards("$keyboard@$langid");

--- a/res/code/bml.php
+++ b/res/code/bml.php
@@ -128,6 +128,14 @@
     echo getutf8(file_get_contents("{$KeymanWebRoot}\\kmwuitoggle.js"));
   }
   
+  // For test hosts only: $StaticResourceDomain='s.keyman.com';
+
+  // Translate $langid into appropriate BCP-47 code, so existing bookmarklets continue to work.
+  // In the future, the bookmarklet registration code at keyman.com/bookmarklet should use BCP-47,
+  // but that won't impact this.
+  require_once('legacy_utils.php'); // Note: this is a clone of api.keyman.com/script/legacy/legacy_utils.php
+  $langid = translate6393ToBCP47($langid);
+
   echo <<<END
 (function() {
   $kmwbase.init({

--- a/res/code/legacy_utils.php
+++ b/res/code/legacy_utils.php
@@ -1,0 +1,258 @@
+<?php
+
+  function dateFormat($date) {
+    global $dateFormatSeconds;
+    if($dateFormatSeconds) {
+      return strtotime($date);
+    } else {
+      return $date;
+    }
+  }
+  
+  // This data is constructed from the standards data. It should never change.
+  // Extracted from http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+
+  $map6393tobcp47 = [
+    'aar' => 'aa',
+    'abk' => 'ab',
+    'afr' => 'af',
+    'aka' => 'ak',
+    'amh' => 'am',
+    'ara' => 'ar',
+    'arg' => 'an',
+    'asm' => 'as',
+    'ava' => 'av',
+    'ave' => 'ae',
+    'aym' => 'ay',
+    'aze' => 'az',
+    'bak' => 'ba',
+    'bam' => 'bm',
+    'bel' => 'be',
+    'ben' => 'bn',
+    'bis' => 'bi',
+    'bod' => 'bo',
+    'bos' => 'bs',
+    'bre' => 'br',
+    'bul' => 'bg',
+    'cat' => 'ca',
+    'ces' => 'cs',
+    'cha' => 'ch',
+    'che' => 'ce',
+    'chu' => 'cu',
+    'chv' => 'cv',
+    'cor' => 'kw',
+    'cos' => 'co',
+    'cre' => 'cr',
+    'cym' => 'cy',
+    'dan' => 'da',
+    'deu' => 'de',
+    'div' => 'dv',
+    'dzo' => 'dz',
+    'ell' => 'el',
+    'eng' => 'en',
+    'epo' => 'eo',
+    'est' => 'et',
+    'eus' => 'eu',
+    'ewe' => 'ee',
+    'fao' => 'fo',
+    'fas' => 'fa',
+    'fij' => 'fj',
+    'fin' => 'fi',
+    'fra' => 'fr',
+    'fry' => 'fy',
+    'ful' => 'ff',
+    'gla' => 'gd',
+    'gle' => 'ga',
+    'glg' => 'gl',
+    'glv' => 'gv',
+    'grn' => 'gn',
+    'guj' => 'gu',
+    'hat' => 'ht',
+    'hau' => 'ha',
+    'hbs' => 'sh',
+    'heb' => 'he',
+    'her' => 'hz',
+    'hin' => 'hi',
+    'hmo' => 'ho',
+    'hrv' => 'hr',
+    'hun' => 'hu',
+    'hye' => 'hy',
+    'ibo' => 'ig',
+    'ido' => 'io',
+    'iii' => 'ii',
+    'iku' => 'iu',
+    'ile' => 'ie',
+    'ina' => 'ia',
+    'ind' => 'id',
+    'ipk' => 'ik',
+    'isl' => 'is',
+    'ita' => 'it',
+    'jav' => 'jv',
+    'jpn' => 'ja',
+    'kal' => 'kl',
+    'kan' => 'kn',
+    'kas' => 'ks',
+    'kat' => 'ka',
+    'kau' => 'kr',
+    'kaz' => 'kk',
+    'khm' => 'km',
+    'kik' => 'ki',
+    'kin' => 'rw',
+    'kir' => 'ky',
+    'kom' => 'kv',
+    'kon' => 'kg',
+    'kor' => 'ko',
+    'kua' => 'kj',
+    'kur' => 'ku',
+    'lao' => 'lo',
+    'lat' => 'la',
+    'lav' => 'lv',
+    'lim' => 'li',
+    'lin' => 'ln',
+    'lit' => 'lt',
+    'ltz' => 'lb',
+    'lub' => 'lu',
+    'lug' => 'lg',
+    'mah' => 'mh',
+    'mal' => 'ml',
+    'mar' => 'mr',
+    'mkd' => 'mk',
+    'mlg' => 'mg',
+    'mlt' => 'mt',
+    'mon' => 'mn',
+    'mri' => 'mi',
+    'msa' => 'ms',
+    'mya' => 'my',
+    'nau' => 'na',
+    'nav' => 'nv',
+    'nbl' => 'nr',
+    'nde' => 'nd',
+    'ndo' => 'ng',
+    'nep' => 'ne',
+    'nld' => 'nl',
+    'nno' => 'nn',
+    'nob' => 'nb',
+    'nor' => 'no',
+    'nya' => 'ny',
+    'oci' => 'oc',
+    'oji' => 'oj',
+    'ori' => 'or',
+    'orm' => 'om',
+    'oss' => 'os',
+    'pan' => 'pa',
+    'pli' => 'pi',
+    'pol' => 'pl',
+    'por' => 'pt',
+    'pus' => 'ps',
+    'que' => 'qu',
+    'roh' => 'rm',
+    'ron' => 'ro',
+    'run' => 'rn',
+    'rus' => 'ru',
+    'sag' => 'sg',
+    'san' => 'sa',
+    'sin' => 'si',
+    'slk' => 'sk',
+    'slv' => 'sl',
+    'sme' => 'se',
+    'smo' => 'sm',
+    'sna' => 'sn',
+    'snd' => 'sd',
+    'som' => 'so',
+    'sot' => 'st',
+    'spa' => 'es',
+    'sqi' => 'sq',
+    'srd' => 'sc',
+    'srp' => 'sr',
+    'ssw' => 'ss',
+    'sun' => 'su',
+    'swa' => 'sw',
+    'swe' => 'sv',
+    'tah' => 'ty',
+    'tam' => 'ta',
+    'tat' => 'tt',
+    'tel' => 'te',
+    'tgk' => 'tg',
+    'tgl' => 'tl',
+    'tha' => 'th',
+    'tir' => 'ti',
+    'ton' => 'to',
+    'tsn' => 'tn',
+    'tso' => 'ts',
+    'tuk' => 'tk',
+    'tur' => 'tr',
+    'twi' => 'tw',
+    'uig' => 'ug',
+    'ukr' => 'uk',
+    'urd' => 'ur',
+    'uzb' => 'uz',
+    'ven' => 've',
+    'vie' => 'vi',
+    'vol' => 'vo',
+    'wln' => 'wa',
+    'wol' => 'wo',
+    'xho' => 'xh',
+    'yid' => 'yi',
+    'yor' => 'yo',
+    'zha' => 'za',
+    'zho' => 'zh',
+    'zul' => 'zu'
+  ];
+  $mapbcp47to6393 = null;
+  
+  function translate6393ToBCP47($id) {
+    // This function just maps ISO639-3 codes to 2 letter codes where one exists, otherwise
+    // returns the three letter code.
+    global $map6393tobcp47;
+    if(isset($map6393tobcp47[$id])) {
+      return $map6393tobcp47[$id];
+    }
+    return $id;
+  }
+  
+  function build_mapbcp47to6393() {
+    global $map6393tobcp47, $mapbcp47to6393;
+    $mapbcp47to6393 = [];
+    foreach($map6393tobcp47 as $iso6393 => $bcp47) {
+      $mapbcp47to6393[$bcp47] = $iso6393;
+    }
+  }
+
+  function translateLanguageIdToOutputFormat($id) {
+    global $use_bcp47;
+    if(!isset($use_bcp47)) {
+      $use_bcp47 = isset($_REQUEST['languageidtype']) && $_REQUEST['languageidtype'] == 'bcp47';
+    }
+    
+    if($use_bcp47) {
+      return $id;
+    }
+
+    if(empty($id)) return $id;
+
+    global $map6393tobcp47, $mapbcp47to6393;
+    if(empty($mapbcp47to6393)) {
+      build_mapbcp47to6393();
+    }
+    
+    $id = explode('-', $id);
+    return isset($mapbcp47to6393[$id[0]]) ? $mapbcp47to6393[$id[0]] : $id[0];
+  }
+  
+  function validateVersion($v) {
+    global $version, $version1, $version2;
+    // Make sure we have a valid version string and return 9.0 if not (based on Desktop version).
+    if(!preg_match('/^\d+\.\d+(\.\d+)*$/', $v)) {
+      $version = '9.0';
+    } else {
+      $version = $v;
+    }
+    preg_match('/^(\d+)\.(\d+)/', $version, $matches);
+    $version1 = $matches[1];
+    /* Because we don't really support KMW keyboards earlier than 2.0, that maps to Keyman Desktop 9.0, we
+       set the version to 9.0 if it is lower than that. */
+    if($version1 < 9) $version1 = 9;
+    $version2 = $matches[2];
+  }
+
+?>


### PR DESCRIPTION
This corrects two problems with the KeymanWeb Bookmarklet:

1. The version code was not checking correctly for existence of stable and beta versions
2. The resource paths were using only build number and not including the full version number as required.

Still an issue: keyboards registered with a BCP47 code instead of an Ethnologue (ISO639-3) code are not handled. This will be addressed separately.

This addresses a reported issue at https://community.software.sil.org/t/bookmarklet-no-longer-working/2330/2